### PR TITLE
Sanitize setState keys to prevent prototype pollution

### DIFF
--- a/core/state/StateManager.js
+++ b/core/state/StateManager.js
@@ -102,6 +102,13 @@ export class StateManager {
       updates = updates(oldState);
     }
 
+    // Sanitize keys to prevent prototype pollution
+    if (updates && typeof updates === 'object') {
+      delete updates.__proto__;
+      delete updates.constructor;
+      delete updates.prototype;
+    }
+
     // Create new state with updates
     const newState = {
       ...oldState,


### PR DESCRIPTION
## Summary
- Reject `__proto__`, `constructor`, and `prototype` keys in `StateManager.setState()` to prevent prototype pollution attacks via user-provided state updates

## Test plan
- [ ] Verify `setState({ __proto__: { polluted: true } })` does not pollute `Object.prototype`
- [ ] Verify normal state updates continue to work as expected