### PR TITLE
Fix week number calculation to follow ISO 8601

### DIFF
--- a/core/calendar/DateUtils.js
+++ b/core/calendar/DateUtils.js
@@ -288,9 +288,13 @@ export class DateUtils {
    * @returns {number}
    */
   static getWeekNumber(date) {
-    const firstDayOfYear = new Date(date.getFullYear(), 0, 1);
-    const pastDaysOfYear = (date - firstDayOfYear) / 86400000;
-    return Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);
+    // ISO 8601: week 1 is the week containing the first Thursday of the year
+    const target = new Date(date);
+    target.setHours(0, 0, 0, 0);
+    // Set to nearest Thursday (current date + 4 - current day number, with Sunday as 7)
+    target.setDate(target.getDate() + 4 - (target.getDay() || 7));
+    const yearStart = new Date(target.getFullYear(), 0, 1);
+    return Math.ceil(((target - yearStart) / 86400000 + 1) / 7);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace naive week number formula with ISO 8601 compliant calculation
- Week 1 is now correctly defined as the week containing the first Thursday of the year
- Fixes incorrect results at December/January year boundaries

## Test plan
- [ ] `getWeekNumber(new Date(2025, 0, 1))` returns 1 (Wednesday, part of week 1)
- [ ] `getWeekNumber(new Date(2016, 0, 1))` returns 53 (Friday, belongs to previous year's last week)
- [ ] `getWeekNumber(new Date(2025, 11, 29))` returns 1 (Monday, part of next year's week 1)