### PR TITLE
Fix ICS parser losing multi-valued categories

### DIFF
--- a/core/ics/ICSParser.js
+++ b/core/ics/ICSParser.js
@@ -160,7 +160,9 @@ export class ICSParser {
     }
 
     // Categories
-    if (event.category) {
+    if (event.categories && event.categories.length > 0) {
+      lines.push(`CATEGORIES:${event.categories.join(',')}`);
+    } else if (event.category) {
       lines.push(`CATEGORIES:${event.category}`);
     }
 
@@ -246,7 +248,8 @@ export class ICSParser {
         break;
 
       case 'CATEGORIES':
-        event.category = value.split(',')[0]; // Take first category
+        event.categories = value.split(',').map(c => c.trim());
+        event.category = event.categories[0];
         break;
 
       case 'STATUS': {


### PR DESCRIPTION
## Summary
- ICS CATEGORIES property supports comma-separated values per RFC 5545
- Parser was only keeping the first category, discarding the rest
- Export was only writing singular `event.category`, not the full array
- Now parses all categories into `categories` array and exports them correctly

## Test plan
- [ ] Parse ICS with `CATEGORIES:WORK,MEETING,IMPORTANT` — verify all 3 categories preserved
- [ ] Export event with multiple categories — verify comma-separated output
- [ ] Backward compatibility: single category still works for both parse and export