### PR TITLE
Fix cache not invalidated on event update and remove

### DIFF
--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -122,6 +122,13 @@ export class EventStore {
     // Store updated event
     this.events.set(eventId, updatedEvent);
 
+    // Update cache with new event data
+    this.optimizer.cache(eventId, updatedEvent, 'event');
+
+    // Clear query and date range caches since results may have changed
+    this.optimizer.queryCache.clear();
+    this.optimizer.dateRangeCache.clear();
+
     // Re-index
     this._indexEvent(updatedEvent);
 
@@ -149,6 +156,11 @@ export class EventStore {
 
     // Remove from primary storage
     this.events.delete(eventId);
+
+    // Invalidate caches
+    this.optimizer.eventCache.delete(eventId);
+    this.optimizer.queryCache.clear();
+    this.optimizer.dateRangeCache.clear();
 
     // Remove from indices
     this._unindexEvent(event);


### PR DESCRIPTION
## Summary
- `updateEvent()` didn't update the optimizer event cache or clear query/dateRange caches
- `removeEvent()` didn't remove from event cache or clear query/dateRange caches
- This caused `getEvent()` to return stale data and queries to include ghost events

## Test plan
- [ ] Update an event, call getEvent() — verify updated data returned
- [ ] Remove an event, call getEvent() — verify null returned
- [ ] Update event time, query by date range — verify correct results