### PR TITLE
Fix timezone cache key to include hour for DST accuracy

### DIFF
--- a/core/timezone/TimezoneManager.js
+++ b/core/timezone/TimezoneManager.js
@@ -110,7 +110,7 @@ export class TimezoneManager {
     timezone = this.database.resolveAlias(timezone);
 
     // Check cache first
-    const cacheKey = `${timezone}_${date.getFullYear()}_${date.getMonth()}_${date.getDate()}`;
+    const cacheKey = `${timezone}_${date.getFullYear()}_${date.getMonth()}_${date.getDate()}_${date.getHours()}`;
     if (this.offsetCache.has(cacheKey)) {
       this.cacheHits++;
       this._manageCacheSize();


### PR DESCRIPTION
## Summary
- Timezone offset cache key was `timezone_year_month_date`, missing the hour
- On DST transition dates, the same date can have two different offsets depending on the hour
- Added hour to the cache key to prevent returning a cached pre-transition offset for a post-transition time

## Test plan
- [ ] Query offset for America/New_York at 1:00 AM on spring forward date
- [ ] Query offset for America/New_York at 3:00 AM on same date
- [ ] Verify different offsets returned (not cached from wrong hour)