### PR TITLE
Enable rollback support for batch operations

### DIFF
--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -998,7 +998,7 @@ export class EventStore {
    */
   addEvents(events) {
     return this.optimizer.measure('addEvents', () => {
-      this.startBatch();
+      this.startBatch(true);
       const results = [];
       const errors = [];
 
@@ -1010,7 +1010,11 @@ export class EventStore {
         }
       }
 
-      this.commitBatch();
+      if (errors.length > 0 && results.length === 0) {
+        this.rollbackBatch();
+      } else {
+        this.commitBatch();
+      }
 
       if (errors.length > 0) {
         console.warn(`Failed to add ${errors.length} events:`, errors);
@@ -1027,7 +1031,7 @@ export class EventStore {
    */
   updateEvents(updates) {
     return this.optimizer.measure('updateEvents', () => {
-      this.startBatch();
+      this.startBatch(true);
       const results = [];
       const errors = [];
 
@@ -1039,7 +1043,11 @@ export class EventStore {
         }
       }
 
-      this.commitBatch();
+      if (errors.length > 0 && results.length === 0) {
+        this.rollbackBatch();
+      } else {
+        this.commitBatch();
+      }
 
       if (errors.length > 0) {
         console.warn(`Failed to update ${errors.length} events:`, errors);
@@ -1056,7 +1064,7 @@ export class EventStore {
    */
   removeEvents(eventIds) {
     return this.optimizer.measure('removeEvents', () => {
-      this.startBatch();
+      this.startBatch(true);
       let removed = 0;
 
       for (const id of eventIds) {
@@ -1065,7 +1073,11 @@ export class EventStore {
         }
       }
 
-      this.commitBatch();
+      if (removed === 0 && eventIds.length > 0) {
+        this.rollbackBatch();
+      } else {
+        this.commitBatch();
+      }
       return removed;
     });
   }


### PR DESCRIPTION
## Summary
- `addEvents()`, `updateEvents()`, `removeEvents()` called `startBatch()` without rollback
- Partial failures were silently committed with no way to recover
- Now enables rollback backup and rolls back when all operations in a batch fail

## Test plan
- [ ] addEvents() with all invalid events — verify store unchanged (rollback)
- [ ] addEvents() with mix of valid/invalid — verify valid ones committed
- [ ] updateEvents() with all missing IDs — verify rollback
- [ ] removeEvents() with all missing IDs — verify rollback