### PR TITLE
Remove unused lastDateTimestamp in RecurrenceEngine

### DIFF
--- a/core/events/RecurrenceEngine.js
+++ b/core/events/RecurrenceEngine.js
@@ -39,8 +39,7 @@ export class RecurrenceEngine {
     // Track DST transitions for proper timezone handling
     let lastOffset = tzManager.getTimezoneOffset(currentDate, eventTimezone);
 
-    // Track last date to detect infinite loop (date not advancing)
-    const lastDateTimestamp = null;
+    // Track stuck iterations to detect infinite loop (date not advancing)
     let stuckCount = 0;
     const maxStuckIterations = 3;
 


### PR DESCRIPTION
## Summary
- The stuck loop detection actually works correctly via `previousTimestamp` (line 76), which is captured each iteration and compared after `getNextOccurrence`
- The `lastDateTimestamp` variable (declared as `const null`) was dead code — never read or updated
- Removed it to avoid confusion

Closes #7

## Test plan
- [ ] Verify recurrence expansion still works for DAILY, WEEKLY, MONTHLY rules
- [ ] Verify stuck loop detection still triggers (mock a rule where date doesn't advance)