### PR TITLE
fix: add ICS parser size limits (#37)

### DIFF
--- a/core/ics/ICSHandler.js
+++ b/core/ics/ICSHandler.js
@@ -31,6 +31,13 @@ export class ICSHandler {
       // Get ICS string from input
       const icsString = await this.getICSString(input);
 
+      // Enforce input size limit before parsing
+      if (typeof icsString === 'string' && icsString.length > ICSParser.MAX_INPUT_SIZE) {
+        throw new Error(
+          `ICS input exceeds maximum size of ${ICSParser.MAX_INPUT_SIZE / (1024 * 1024)}MB`
+        );
+      }
+
       // Parse ICS to events
       const parsedEvents = this.parser.parse(icsString);
 


### PR DESCRIPTION
## Summary
- Adds static size limits to `ICSParser` to prevent denial-of-service via oversized ICS files
- `MAX_INPUT_SIZE`: 50MB max input string length
- `MAX_LINES`: 100k max lines after unfolding
- `MAX_EVENTS`: 10k max VEVENT components per file
- Limits enforced in both `ICSParser.parse()` and `ICSHandler.import()` with descriptive errors

## Files Changed
- `core/ics/ICSParser.js` — added static limits and enforcement checks in `parse()`
- `core/ics/ICSHandler.js` — added early size check in `import()` before parsing

## Test Plan
- [ ] Verify normal ICS files parse correctly
- [ ] Verify error thrown for input exceeding 50MB
- [ ] Verify error thrown for input with >100k lines
- [ ] Verify error thrown for input with >10k events

Closes #37