### PR TITLE
fix: validate BYWEEKNO at parse time (#57)

### DIFF
--- a/core/events/RRuleParser.js
+++ b/core/events/RRuleParser.js
@@ -63,7 +63,10 @@ export class RRuleParser {
           break;
 
         case 'BYWEEKNO':
-          rule.byWeekNo = this.parseIntList(value);
+          // RFC 5545: valid range is 1-53 or -53 to -1 (no zero)
+          rule.byWeekNo = this.parseIntList(value).filter(
+            v => v !== 0 && v >= -53 && v <= 53
+          );
           break;
 
         case 'BYMONTH':
@@ -242,6 +245,7 @@ export class RRuleParser {
     rule.byMonth = validateArray(rule.byMonth || [], 1, 12);
     rule.byMonthDay = validateArray(rule.byMonthDay || [], -31, 31).filter(v => v !== 0);
     rule.byYearDay = validateArray(rule.byYearDay || [], -366, 366).filter(v => v !== 0);
+    // RFC 5545: BYWEEKNO valid range is 1-53 or -53 to -1
     rule.byWeekNo = validateArray(rule.byWeekNo || [], -53, 53).filter(v => v !== 0);
     rule.byHour = validateArray(rule.byHour || [], 0, 23);
     rule.byMinute = validateArray(rule.byMinute || [], 0, 59);


### PR DESCRIPTION
## Summary
- Adds immediate validation of BYWEEKNO values during RRULE parsing
- Per RFC 5545, valid week numbers are 1-53 or -53 to -1 (zero is invalid)
- Previously, raw integer values were stored without filtering until `validateRule()` was called
- Now invalid values (0, out of range) are filtered at parse time in the `BYWEEKNO` case handler
- Added clarifying RFC 5545 comment to the `validateRule()` method

## Files Changed
- `core/events/RRuleParser.js` — added range filter in BYWEEKNO case and RFC comment in validateRule

## Test Plan
- [ ] Verify valid BYWEEKNO values (1-53, -53 to -1) are preserved
- [ ] Verify zero is filtered out
- [ ] Verify values outside -53..53 range are filtered out
- [ ] Verify normal RRULE parsing still works

Closes #57