### PR TITLE
Fix #76: queryEvents() month boundary timezone fix

### DIFF
--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -234,9 +234,30 @@ export class EventStore {
 
     // Filter by month
     if (filters.month && filters.year) {
-      const monthKey = `${filters.year}-${String(filters.month).padStart(2, '0')}`;
-      const eventIds = this.indices.byMonth.get(monthKey) || new Set();
-      results = results.filter(event => eventIds.has(event.id));
+      // Collect candidates from target month AND adjacent months to handle
+      // timezone boundary issues (events indexed in the event's own timezone
+      // may fall in a different month than the query month)
+      const candidateIds = new Set();
+      for (let offset = -1; offset <= 1; offset++) {
+        let m = filters.month + offset;
+        let y = filters.year;
+        if (m < 1) { m = 12; y--; }
+        if (m > 12) { m = 1; y++; }
+        const key = `${y}-${String(m).padStart(2, '0')}`;
+        const ids = this.indices.byMonth.get(key);
+        if (ids) {
+          ids.forEach(id => candidateIds.add(id));
+        }
+      }
+
+      // Post-filter: only include events that actually overlap with the requested month
+      const monthStart = new Date(filters.year, filters.month - 1, 1);
+      const monthEnd = new Date(filters.year, filters.month, 0, 23, 59, 59, 999);
+
+      results = results.filter(event => {
+        if (!candidateIds.has(event.id)) return false;
+        return event.start <= monthEnd && event.end >= monthStart;
+      });
     }
 
     // Filter by all-day events


### PR DESCRIPTION
## Summary
- Fixes EventStore.queryEvents() missing events at month boundaries in non-UTC timezones
- The byMonth index is built using each event's own timezone, so events near month boundaries can be indexed in a different month than expected by the query
- Now checks adjacent months (prev/next) when filtering by month and post-filters candidates by actual date overlap with the requested month period

## Test plan
- [ ] Verify events on Jan 31 UTC appear in January queries even when indexed under February (Asia/Tokyo)
- [ ] Verify events spanning month boundaries are returned correctly
- [ ] Verify no regression for standard same-timezone queries

Fixes #76

Generated with [Claude Code](https://claude.com/claude-code)