### PR TITLE
Fix #78: ICSParser.parse() DoS - add input size validation

### DIFF
--- a/core/ics/ICSParser.js
+++ b/core/ics/ICSParser.js
@@ -10,7 +10,10 @@ export class ICSParser {
   static MAX_LINES = 100000; // 100k lines
   static MAX_EVENTS = 10000; // 10k events
 
-  constructor() {
+  constructor(options = {}) {
+    // Configurable max file size (defaults to static limit)
+    this.maxFileSize = options.maxFileSize || ICSParser.MAX_INPUT_SIZE;
+
     // ICS line folding max width
     this.maxLineLength = 75;
 
@@ -38,10 +41,13 @@ export class ICSParser {
    * @returns {Array} Array of event objects
    */
   parse(icsString) {
-    // Enforce input size limit
-    if (typeof icsString === 'string' && icsString.length > ICSParser.MAX_INPUT_SIZE) {
+    if (typeof icsString !== 'string') {
+      throw new Error('ICS input must be a string');
+    }
+    // Enforce input size limit (uses instance config, falling back to static default)
+    if (icsString.length > this.maxFileSize) {
       throw new Error(
-        `ICS input exceeds maximum size of ${ICSParser.MAX_INPUT_SIZE / (1024 * 1024)}MB`
+        `ICS input exceeds maximum size of ${this.maxFileSize / (1024 * 1024)}MB`
       );
     }
 


### PR DESCRIPTION
## Summary
- Adds a configurable `maxFileSize` limit (default 10MB) to `ICSParser` constructor
- Validates input type (must be string) and size before parsing begins
- Prevents memory exhaustion from untrusted multi-gigabyte ICS input

## Test plan
- [ ] Verify parsing normal ICS files still works
- [ ] Verify ICS input exceeding 10MB throws an error
- [ ] Verify non-string input throws an error
- [ ] Verify custom `maxFileSize` option is respected

Fixes #78

Generated with [Claude Code](https://claude.com/claude-code)