### PR TITLE
Fix #65: DST-safe differenceInDays arithmetic

### DIFF
--- a/core/calendar/DateUtils.js
+++ b/core/calendar/DateUtils.js
@@ -256,8 +256,11 @@ export class DateUtils {
    * @returns {number}
    */
   static differenceInDays(date1, date2) {
-    const diff = date1.getTime() - date2.getTime();
-    return Math.floor(diff / (1000 * 60 * 60 * 24));
+    // Normalize to midnight to avoid DST-related hour differences
+    const d1 = new Date(date1.getFullYear(), date1.getMonth(), date1.getDate());
+    const d2 = new Date(date2.getFullYear(), date2.getMonth(), date2.getDate());
+    const diff = d1.getTime() - d2.getTime();
+    return Math.round(diff / (1000 * 60 * 60 * 24));
   }
 
   /**


### PR DESCRIPTION
## Summary
- Normalizes both dates to midnight using `new Date(year, month, date)` before computing the difference
- Uses `Math.round` instead of `Math.floor` to handle any residual sub-day differences from DST transitions
- Consistent with the rest of DateUtils which uses `setDate()` for DST-safe date arithmetic

## Test plan
- [ ] Verify correct day count across spring-forward DST boundary (e.g., Mar 9 to Mar 10 in US timezones)
- [ ] Verify correct day count across fall-back DST boundary
- [ ] Verify `differenceInWeeks()` still works correctly (delegates to `differenceInDays`)
- [ ] Verify no regression for same-day and multi-day differences

Fixes #65

Generated with [Claude Code](https://claude.com/claude-code)