### PR TITLE
Fix #66: Parse EXDATE exclusion dates in ICSParser

### DIFF
--- a/core/ics/ICSParser.js
+++ b/core/ics/ICSParser.js
@@ -284,6 +284,13 @@ export class ICSParser {
         event.recurrenceRule = value;
         event.recurring = true;
         break;
+
+      case 'EXDATE': {
+        if (!event.excludeDates) event.excludeDates = [];
+        const dates = value.split(',').map(d => this.parseDate(d.trim(), property));
+        event.excludeDates.push(...dates.filter(d => d !== null));
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds missing `case 'EXDATE'` handler in `parseProperty()` switch statement
- Parses comma-separated EXDATE values using the existing `parseDate()` method
- Handles both DATE and DATE-TIME formats per RFC 5545
- Initializes `excludeDates` array lazily to support multiple EXDATE lines

## Test plan
- [ ] Verify EXDATE values are parsed from ICS input into `excludeDates` array
- [ ] Verify comma-separated EXDATE values are all captured
- [ ] Verify both DATE (20240315) and DATE-TIME (20240315T120000Z) formats work
- [ ] Verify recurring events with EXDATE properly exclude those dates

Fixes #66

Generated with [Claude Code](https://claude.com/claude-code)