### PR TITLE
Fix #68: Clear byCategory and byStatus in EventStore.clear()

### DIFF
--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -618,6 +618,8 @@ export class EventStore {
     this.indices.byDate.clear();
     this.indices.byMonth.clear();
     this.indices.recurring.clear();
+    this.indices.byCategory.clear();
+    this.indices.byStatus.clear();
 
     this._notifyChange({
       type: 'clear',


### PR DESCRIPTION
## Summary
- Adds missing `this.indices.byCategory.clear()` and `this.indices.byStatus.clear()` calls to `EventStore.clear()`
- Prevents stale index references after clearing all events
- Fixes memory leak and incorrect category/status query results after clear

## Test plan
- [ ] Verify `clear()` empties all indices including byCategory and byStatus
- [ ] Verify queries by category return empty results after clear
- [ ] Verify queries by status return empty results after clear
- [ ] Verify `loadEvents()` (which calls `clear()`) works correctly

Fixes #68

Generated with [Claude Code](https://claude.com/claude-code)