### PR TITLE
Fix NPM publish retry for yanked versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -89,9 +89,19 @@ jobs:
 
         echo "Bump type: $BUMP_TYPE"
 
-        NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version)
+        # Bump and verify the version is publishable (retry up to 5 times for yanked versions)
+        for i in 1 2 3 4 5; do
+          NEW_VERSION=$(npm version patch --no-git-tag-version)
+          echo "Trying version: $NEW_VERSION"
+          if npm publish --dry-run 2>&1 | grep -q "E403"; then
+            echo "Version $NEW_VERSION is blocked (previously published/unpublished). Bumping again..."
+          else
+            break
+          fi
+        done
+
         echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-        echo "Calculated new version: $NEW_VERSION"
+        echo "Final version: $NEW_VERSION"
 
     - name: Check if version already exists
       id: check_version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forcecalendar/core",
-  "version": "2.1.22",
+  "version": "2.1.23",
   "type": "module",
   "private": false,
   "description": "A modern, lightweight, framework-agnostic calendar engine optimized for Salesforce",


### PR DESCRIPTION
## Summary
- Adds retry loop (up to 5 attempts) in the "Determine and Bump Version" step that uses `npm publish --dry-run` to detect E403 errors from previously unpublished/yanked versions
- Automatically bumps past blocked versions instead of failing
- Bumps package.json from 2.1.22 to 2.1.23 to skip the permanently blocked version

## Context
Version 2.1.22 was published then unpublished. NPM permanently blocks re-use of unpublished versions, but `npm view` can't find them, so the existing "Check if version already exists" step passed. The actual `npm publish` then failed with E403.

## Test plan
- [ ] Verify workflow no longer gets stuck on blocked v2.1.22
- [ ] Verify retry loop correctly detects E403 and bumps past it
- [ ] Verify normal publishes (no blocked versions) still work on first attempt

Generated with [Claude Code](https://claude.com/claude-code)