### PR TITLE
Fix NPM publish: respect local version over NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,11 +62,16 @@ jobs:
       run: |
         PACKAGE_NAME=$(node -e "console.log(require('./package.json').name)")
 
-        # Get latest version from NPM (source of truth), fallback to local
+        # Sync to NPM version only if NPM is ahead of local
         NPM_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "")
+        LOCAL_VERSION=$(node -e "console.log(require('./package.json').version)")
         if [ -n "$NPM_VERSION" ]; then
-          echo "Syncing to NPM version: $NPM_VERSION"
-          npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version
+          if npx semver "$NPM_VERSION" -r ">$LOCAL_VERSION" > /dev/null 2>&1; then
+            echo "NPM version $NPM_VERSION is ahead of local $LOCAL_VERSION, syncing"
+            npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version
+          else
+            echo "Local version $LOCAL_VERSION is ahead of or equal to NPM $NPM_VERSION, keeping local"
+          fi
         fi
 
         # Determine bump type from commit message or manual input
@@ -89,19 +94,9 @@ jobs:
 
         echo "Bump type: $BUMP_TYPE"
 
-        # Bump and verify the version is publishable (retry up to 5 times for yanked versions)
-        for i in 1 2 3 4 5; do
-          NEW_VERSION=$(npm version patch --no-git-tag-version)
-          echo "Trying version: $NEW_VERSION"
-          if npm publish --dry-run 2>&1 | grep -q "E403"; then
-            echo "Version $NEW_VERSION is blocked (previously published/unpublished). Bumping again..."
-          else
-            break
-          fi
-        done
-
+        NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version)
         echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-        echo "Final version: $NEW_VERSION"
+        echo "Calculated new version: $NEW_VERSION"
 
     - name: Check if version already exists
       id: check_version


### PR DESCRIPTION
## Summary
- Only sync package.json to NPM's version if NPM is actually ahead of local (using `npx semver` comparison)
- Removes broken dry-run retry loop (lacked `NODE_AUTH_TOKEN`, couldn't detect E403)
- Restores standard `npm version $BUMP_TYPE` bump from the correct base version

## Context
The previous fix (PR #84) bumped package.json to 2.1.23 to skip blocked v2.1.22, but the workflow unconditionally synced back to NPM's latest (2.1.21) before bumping, landing on 2.1.22 again. This fix ensures the local version is preserved when it's already ahead.

## Test plan
- [ ] Verify workflow uses local 2.1.23 (not NPM's 2.1.21) as the base for bumping
- [ ] Verify publish succeeds with v2.1.24 (2.1.23 + patch bump)
- [ ] Verify workflow still syncs correctly if NPM somehow gets ahead of local

Generated with [Claude Code](https://claude.com/claude-code)