### PR TITLE
Fix prettier formatting in 5 source files

### DIFF
--- a/core/events/Event.js
+++ b/core/events/Event.js
@@ -47,8 +47,12 @@ export class Event {
     }
 
     // Normalize string fields with size limits
-    normalized.id = String(normalized.id || '').trim().slice(0, Event.FIELD_LIMITS.id);
-    normalized.title = String(normalized.title || '').trim().slice(0, Event.FIELD_LIMITS.title);
+    normalized.id = String(normalized.id || '')
+      .trim()
+      .slice(0, Event.FIELD_LIMITS.id);
+    normalized.title = String(normalized.title || '')
+      .trim()
+      .slice(0, Event.FIELD_LIMITS.title);
     normalized.description = String(normalized.description || '')
       .trim()
       .slice(0, Event.FIELD_LIMITS.description);

--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -241,8 +241,14 @@ export class EventStore {
       for (let offset = -1; offset <= 1; offset++) {
         let m = filters.month + offset;
         let y = filters.year;
-        if (m < 1) { m = 12; y--; }
-        if (m > 12) { m = 1; y++; }
+        if (m < 1) {
+          m = 12;
+          y--;
+        }
+        if (m > 12) {
+          m = 1;
+          y++;
+        }
         const key = `${y}-${String(m).padStart(2, '0')}`;
         const ids = this.indices.byMonth.get(key);
         if (ids) {

--- a/core/events/RRuleParser.js
+++ b/core/events/RRuleParser.js
@@ -64,9 +64,7 @@ export class RRuleParser {
 
         case 'BYWEEKNO':
           // RFC 5545: valid range is 1-53 or -53 to -1 (no zero)
-          rule.byWeekNo = this.parseIntList(value).filter(
-            v => v !== 0 && v >= -53 && v <= 53
-          );
+          rule.byWeekNo = this.parseIntList(value).filter(v => v !== 0 && v >= -53 && v <= 53);
           break;
 
         case 'BYMONTH':

--- a/core/ics/ICSHandler.js
+++ b/core/ics/ICSHandler.js
@@ -228,7 +228,9 @@ export class ICSHandler {
 
     // Only allow http and https schemes
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error(`URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted`);
+      throw new Error(
+        `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted`
+      );
     }
 
     const hostname = parsed.hostname.toLowerCase();

--- a/core/ics/ICSParser.js
+++ b/core/ics/ICSParser.js
@@ -46,9 +46,7 @@ export class ICSParser {
     }
     // Enforce input size limit (uses instance config, falling back to static default)
     if (icsString.length > this.maxFileSize) {
-      throw new Error(
-        `ICS input exceeds maximum size of ${this.maxFileSize / (1024 * 1024)}MB`
-      );
+      throw new Error(`ICS input exceeds maximum size of ${this.maxFileSize / (1024 * 1024)}MB`);
     }
 
     const events = [];


### PR DESCRIPTION
## Summary
- Auto-formatted 5 files with `prettier --write` to fix the failing Code Quality CI check
- Changes are whitespace/line-wrapping only — no logic changes
- Files: Event.js, EventStore.js, RRuleParser.js, ICSHandler.js, ICSParser.js

## Root cause
The recent bug fix PRs (#79-#83) introduced code that didn't match prettier's formatting rules.