### PR TITLE
Fix #73: EventStore.loadEvents() now uses batch mode

### DIFF
--- a/core/events/EventStore.js
+++ b/core/events/EventStore.js
@@ -662,9 +662,11 @@ export class EventStore {
   loadEvents(events) {
     this.clear();
 
+    this.startBatch();
     for (const eventData of events) {
       this.addEvent(eventData);
     }
+    this.commitBatch();
   }
 
   /**


### PR DESCRIPTION
## Fix

Wrapped the `loadEvents()` loop in `startBatch()`/`commitBatch()` (EventStore.js:662-668).

Previously, each `addEvent()` call triggered an individual notification to subscribers. For loading 1000 events, this meant 1000 separate notifications causing unnecessary re-renders. Now defers all notifications until loading is complete, emitting a single batch notification.

## Files Changed
- `core/events/EventStore.js` — 2 lines added

Fixes #73