### PR TITLE
Fix #74: Optimize ConflictDetector._checkAttendeeConflicts O(n*m) → O(n+m)

### DIFF
--- a/core/conflicts/ConflictDetector.js
+++ b/core/conflicts/ConflictDetector.js
@@ -320,16 +320,11 @@ export class ConflictDetector {
       return conflicts;
     }
 
-    const conflictingAttendees = [];
-
-    for (const attendee1 of event1.attendees) {
-      for (const attendee2 of event2.attendees) {
-        if (attendee1.email === attendee2.email) {
-          // Same attendee in both events
-          conflictingAttendees.push(attendee1.email);
-        }
-      }
-    }
+    // Use Set for O(1) lookup instead of O(n*m) nested loops
+    const emails1 = new Set(event1.attendees.map(a => a.email));
+    const conflictingAttendees = event2.attendees
+      .filter(a => emails1.has(a.email))
+      .map(a => a.email);
 
     if (conflictingAttendees.length > 0) {
       // Determine severity based on attendee responses


### PR DESCRIPTION
## Fix

Replaced nested for-loops with Set-based lookup in `_checkAttendeeConflicts()` (ConflictDetector.js:323-328).

Previously used O(n*m) nested loops to find overlapping attendees. For enterprise events with 50-100 attendees each, this meant 2500-10000 comparisons per event pair. Now uses a Set for O(1) email lookup, reducing overall complexity to O(n+m).

## Files Changed
- `core/conflicts/ConflictDetector.js` — 5 lines added, 10 removed

Fixes #74